### PR TITLE
Remove standard Python libraries from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 pydub
-json
-glob
-os
-argparse
 gdown

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydub
 gdown
 numpy
 Cython
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pydub
 gdown
+numpy
+Cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gdown
 numpy
 Cython
 scipy
+torch


### PR DESCRIPTION
Remove standard Python libraries from `requirements.txt`.
Add more required libs.